### PR TITLE
Update comparators to comply with C++20 const strictness

### DIFF
--- a/code/data-structures/heap.cpp
+++ b/code/data-structures/heap.cpp
@@ -2,7 +2,7 @@
 #define SWP(x,y) tmp = x, x = y, y = tmp
 struct default_int_cmp {
   default_int_cmp() { }
-  bool operator ()(const int &a, const int &b) {
+  bool operator ()(const int &a, const int &b) const {
     return a < b; } };
 template <class Compare = default_int_cmp> struct heap {
   int len, count, *q, *loc, tmp;

--- a/code/data-structures/kd_tree.cpp
+++ b/code/data-structures/kd_tree.cpp
@@ -11,7 +11,7 @@ template <int K> struct kd_tree {
   struct cmp {
     int c;
     cmp(int _c) : c(_c) {}
-    bool operator ()(const pt &a, const pt &b) {
+    bool operator ()(const pt &a, const pt &b) const {
       for (int i = 0, cc; i <= K; i++) {
         cc = i == 0 ? c : i - 1;
         if (abs(a.coord[cc] - b.coord[cc]) > EPS)

--- a/code/geometry/closest_pair.cpp
+++ b/code/geometry/closest_pair.cpp
@@ -1,11 +1,11 @@
 #include "primitives.cpp"
 
 struct cmpx { bool operator ()(const point &a,
-                               const point &b) {
+                               const point &b) const {
     return abs(real(a) - real(b)) > EPS ?
       real(a) < real(b) : imag(a) < imag(b); } };
 struct cmpy { bool operator ()(const point &a,
-                               const point &b) {
+                               const point &b) const {
   return abs(imag(a) - imag(b)) > EPS ?
       imag(a) < imag(b) : real(a) < real(b); } };
 double closest_pair(vector<point> pts) {

--- a/code/geometry/convex_hull3d.cpp
+++ b/code/geometry/convex_hull3d.cpp
@@ -1,11 +1,11 @@
 #include "primitives3d.cpp"
 double mixed(P(a), P(b), P(c)) { return a % (b * c); }
-bool cmpy(point3d& a, point3d& b) {
+bool cmpy(const point3d& a, const point3d& b) {
   if (abs(a.y-b.y) > EPS) return a.y < b.y;
   if (abs(a.x-b.x) > EPS) return a.x < b.x;
   return a.z < b.z; }
 point3d slp;
-bool cmpsl(point3d& a, point3d& b) {
+bool cmpsl(const point3d& a, const point3d& b) {
   point3d ad = a-slp, bd = b-slp;
   return atan2(ad.y, sqrt(ad.x*ad.x + ad.z*ad.z)) <
          atan2(bd.y, sqrt(bd.x*bd.x + bd.z*bd.z)); }

--- a/code/graph/dijkstra.cpp
+++ b/code/graph/dijkstra.cpp
@@ -1,6 +1,6 @@
 int *dist, *dad;
 struct cmp {
-  bool operator()(int a, int b) {
+  bool operator()(int a, int b) const {
     return dist[a] != dist[b] ? dist[a] < dist[b] : a < b; }
 };
 pair<int*, int*> dijkstra(int n, int s, vii *adj) {

--- a/code/graph/edmonds_karps_mcmf.cpp
+++ b/code/graph/edmonds_karps_mcmf.cpp
@@ -1,6 +1,6 @@
 #define MAXV 2000
 int d[MAXV], p[MAXV], pot[MAXV];
-struct cmp { bool operator ()(int i, int j) {
+struct cmp { bool operator()(int i, int j) const {
     return d[i] == d[j] ? i < j : d[i] < d[j]; } };
 struct flow_network {
   struct edge { int v, nxt, cap, cost;

--- a/code/strings/suffix_array.test.cpp
+++ b/code/strings/suffix_array.test.cpp
@@ -5,7 +5,7 @@ struct cmp {
   int *idx;
   string s;
   cmp(int *_idx, string _s) : idx(_idx), s(_s) { }
-  bool operator()(int a, int b) {
+  bool operator()(int a, int b) const {
     return s.substr(a) < s.substr(b);
   }
 };


### PR DESCRIPTION
Some were necessary for compilation, others are not explicitly necessary but may allow for compiler optimizations, don't see the harm in adding them since they don't force a line break.

Note that when comparing copies it is enough to add const specifier on the function but when comparing references the references must also be const.

I didn't update the tester to use c++20 instead of c++17, maybe it should be updated though.