### PR TITLE
Remove GCC optimization flags from header

### DIFF
--- a/code/header.cpp
+++ b/code/header.cpp
@@ -1,5 +1,3 @@
-#pragma GCC optimize("Ofast","unroll-loops")
-#pragma GCC target("avx2,fma")
 #include <bits/stdc++.h>
 using namespace std;
 #define rep(i,a,b) for (__typeof(a) i=(a); i<(b); ++i)


### PR DESCRIPTION
They cause compile errors in std::set.